### PR TITLE
Add giants

### DIFF
--- a/core/src/main/java/dev/ratas/aggressiveanimals/aggressive/settings/MobType.java
+++ b/core/src/main/java/dev/ratas/aggressiveanimals/aggressive/settings/MobType.java
@@ -95,6 +95,7 @@ public enum MobType {
     allay("ALLAY"),
     camel("CAMEL"),
     sniffer("SNIFFER"),
+    giant(EntityType.GIANT),
     ;
 
     private static final Map<EntityType, MobType> REVERSE_MAP = new EnumMap<>(EntityType.class);

--- a/core/src/main/java/dev/ratas/aggressiveanimals/aggressive/settings/type/PlayerStateSettings.java
+++ b/core/src/main/java/dev/ratas/aggressiveanimals/aggressive/settings/type/PlayerStateSettings.java
@@ -58,7 +58,7 @@ public record PlayerStateSettings(Setting<Boolean> attackStanding, Setting<Boole
         if (player.isGliding()) {
             return false;
         }
-        return player.getVelocity().lengthSquared() == 0; // only if NOT moving
+        return true;
     }
 
     private boolean isWalking(Player player) {

--- a/main/src/main/resources/config.yml
+++ b/main/src/main/resources/config.yml
@@ -116,6 +116,8 @@ mobs:
     enabled: false
     speed-multiplier: 1.5
     attack-leap-height: 0.3
+  giant:
+    enabled: false
   glow_squid:
     enabled: false
   goat:

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,6 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <project-version>1.5.2</project-version>
+    <project-version>1.5.3-SNAPSHOT</project-version>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,6 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <project-version>1.5.3-SNAPSHOT</project-version>
+    <project-version>1.6.0</project-version>
   </properties>
 </project>


### PR DESCRIPTION
Add giants to plugin.

Also a small change to player state detection.
A standing player is no longer required to be standing still.
Previously, a mob would need to be standing still for it to be considered "standing". Yet standing would be a pre-requisite for walking. So this would sometimes lead to a situation where a player is not a suitable target when they should have been.